### PR TITLE
Added MIT Licence badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ We value the time and effort you put into contributing, and we look forward to r
 
 The project is licensed under the [MIT License](https://github.com/neelshah2409/Bot-Collection/blob/main/LICENSE).
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ---


### PR DESCRIPTION
## Related Issue

Issue #1837

## Description

The issue was:
The readme file of the repo should have a MIT Licenses badge and some more text regarding licenses in the Licenses section to make it more professional.

So to resolve I have added the MIT Licence.

## Screenshots
<img width="419" alt="Screenshot 2023-07-24 at 9 36 14 PM" src="https://github.com/SaketKaswa20/ProjectsHut/assets/105808363/bfc61bf3-4870-4083-a145-04c7a0b11afa">

<!-- Add screenshots to preview the changes  -->
